### PR TITLE
Removing colors configuration duplicate

### DIFF
--- a/src/nord.sh
+++ b/src/nord.sh
@@ -73,11 +73,6 @@ apply() {
   _write highlight-background-color "'$nord8_rgb'"
   log 4 "Applied highlight colors and configuration"
 
-  _write highlight-colors-set "true"
-  _write highlight-foreground-color "'$nord0_rgb'"
-  _write highlight-background-color "'$nord8_rgb'"
-  log 4 "Applied highlight colors and configuration"
-
   _write "$NORD_GNOME_TERMINAL_VERSION_DCONF_KEY" "'$NORD_GNOME_TERMINAL_VERSION'"
   log 4 "Set Nord GNOME Terminal version key of the '$profile_name' profile"
 


### PR DESCRIPTION
In nord.sh, lines 71 to 75 and 76 to 80 were the exact same.

Edit:
Found out it was actually an issue.
Fix #29 